### PR TITLE
Leaving Message Mobile Fix

### DIFF
--- a/src/events/leaving-message/index.ts
+++ b/src/events/leaving-message/index.ts
@@ -22,7 +22,7 @@ const event: BotEvent = (client) => {
         throw new Error(`Leaving channel is not text channel for guild with id ${guild.id}!`);
       }
       await channel.send({
-        content: message.replace(/<@>/g, `<@${member.id}>`),
+        content: message.replace(/<@>/g, `<@${member.id}> (${member.user?.tag || member.displayName})`),
       });
     } catch (err) {
       onError(err);


### PR DESCRIPTION
Add the user tag or member display name in brackets after mention because the mention does not resolve in mobile client.